### PR TITLE
DriverCleanupModule: Add USB-To-Serial (libwdi)

### DIFF
--- a/src/TabletDriverCleanup/Guids.cs
+++ b/src/TabletDriverCleanup/Guids.cs
@@ -4,4 +4,5 @@ public static class Guids
 {
     public static readonly Guid HIDClass = new("{745a17a0-74d3-11d0-b6fe-00a0c90f57da}");
     public static readonly Guid USBDevice = new("{88bae032-5a81-49f0-bc3d-a4ff138216d6}");
+    public static readonly Guid Ports = new("{4d36e978-e325-11ce-bfc1-08002be10318}");
 }

--- a/src/TabletDriverCleanup/Modules/DriverCleanupModule.cs
+++ b/src/TabletDriverCleanup/Modules/DriverCleanupModule.cs
@@ -48,7 +48,12 @@ public class DriverCleanupModule : ICleanupModule
             friendlyName: "WinUSB (libwdi)",
             originalName: @".*",
             providerName: "libwdi",
-            classGuid: Guids.USBDevice)
+            classGuid: Guids.USBDevice),
+        new DriverToUninstall(
+            friendlyName: "USB-To-Serial (libwdi)",
+            originalName: @".*",
+            providerName: "libwdi",
+            classGuid: Guids.Ports)
     );
 
     public string Name { get; } = "Driver Cleanup";


### PR DESCRIPTION
Reference:

devices.json
```js
  {
    "IsGeneric": true,
    "InstanceId": "USB\\VID_056A&PID_0376\\8IH00S2035415",
    "HardwareIds": [
      "USB\\VID_056A&PID_0376&REV_0111",
      "USB\\VID_056A&PID_0376"
    ],
    "Description": "Intuos BT S",
    "FriendlyName": "Intuos BT S (COM6)",
    "Manufacturer": "Wacom Co., Ltd",
    "DriverName": "{4d36e978-e325-11ce-bfc1-08002be10318}\\0003",
    "Class": "Ports",
    "ClassGuid": "4d36e978-e325-11ce-bfc1-08002be10318",
    "InfName": "oem30.inf",
    "InfOriginalName": "intuos_bt_s.inf",
    "InfSection": "UsbSer_Install",
    "InfProvider": "libwdi",
    "DriverStoreLocation": "C:\\Windows\\System32\\DriverStore\\FileRepository\\intuos_bt_s.inf_amd64_b2b19be43bd4bf79"
  }
```

drivers.json
```js
  {
    "InfName": "oem30.inf",
    "InfOriginalName": "intuos_bt_s.inf",
    "DriverStoreLocation": "C:\\Windows\\System32\\DriverStore\\FileRepository\\intuos_bt_s.inf_amd64_b2b19be43bd4bf79",
    "Provider": "libwdi",
    "Class": "Ports",
    "ClassGuid": "4d36e978-e325-11ce-bfc1-08002be10318"
  }
```