### PR TITLE
Move identifiers to JSON and allow hot updating

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,7 @@
             "program": "${workspaceFolder}/src/TabletDriverCleanup/bin/Debug/net7.0/TabletDriverCleanup.dll",
             "args": [
                 "--no-prompt",
+                "--no-cache",
                 "--dry-run"
             ],
             "cwd": "${workspaceFolder}/src/TabletDriverCleanup",

--- a/TabletDriverCleanup.sln
+++ b/TabletDriverCleanup.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B1CC8E3E-CFBC-4FF0-8AE3-800B31C41B1D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PnpUtil", "src\PnpUtil\PnpUtil.csproj", "{580D2ABE-09B3-469E-9401-90875F41F1A9}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TabletDriverCleanup", "src\TabletDriverCleanup\TabletDriverCleanup.csproj", "{C9B6B3F7-54E4-4D05-863B-D9EB9FAB82BC}"
 EndProject
 Global
@@ -22,18 +20,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Debug|x64.Build.0 = Debug|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Debug|x86.Build.0 = Debug|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Release|x64.ActiveCfg = Release|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Release|x64.Build.0 = Release|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Release|x86.ActiveCfg = Release|Any CPU
-		{580D2ABE-09B3-469E-9401-90875F41F1A9}.Release|x86.Build.0 = Release|Any CPU
 		{C9B6B3F7-54E4-4D05-863B-D9EB9FAB82BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C9B6B3F7-54E4-4D05-863B-D9EB9FAB82BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9B6B3F7-54E4-4D05-863B-D9EB9FAB82BC}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -48,7 +34,6 @@ Global
 		{C9B6B3F7-54E4-4D05-863B-D9EB9FAB82BC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{580D2ABE-09B3-469E-9401-90875F41F1A9} = {B1CC8E3E-CFBC-4FF0-8AE3-800B31C41B1D}
 		{C9B6B3F7-54E4-4D05-863B-D9EB9FAB82BC} = {B1CC8E3E-CFBC-4FF0-8AE3-800B31C41B1D}
 	EndGlobalSection
 EndGlobal

--- a/config/device_identifiers.json
+++ b/config/device_identifiers.json
@@ -1,0 +1,14 @@
+[
+  {
+    "FriendlyName": "Wacom Driver Downloader",
+    "DeviceDescription": "Wacom Driver Downloader",
+    "ManufacturerName": "Wacom Technology"
+  },
+  {
+    "FriendlyName": "VMulti Device",
+    "DeviceDescription": "Pentablet HID",
+    "ManufacturerName": "Pentablet HID",
+    "HardwareID": "pentablet\\\\hid",
+    "ClassGuid": "745a17a0-74d3-11d0-b6fe-00a0c90f57da"
+  }
+]

--- a/config/driver_identifiers.json
+++ b/config/driver_identifiers.json
@@ -1,0 +1,44 @@
+[
+  {
+    "FriendlyName": "VMulti",
+    "OriginalName": "vmulti\\.inf",
+    "ProviderName": "Pentablet HID",
+    "ClassGuid": "745a17a0-74d3-11d0-b6fe-00a0c90f57da"
+  },
+  {
+    "FriendlyName": "VMulti (Huion)",
+    "OriginalName": "vmulti\\.inf",
+    "ProviderName": "[H|h][U|u][I|i][O|o][N|n]",
+    "ClassGuid": "745a17a0-74d3-11d0-b6fe-00a0c90f57da"
+  },
+  {
+    "FriendlyName": "WinUSB (Hawku/Huion)",
+    "OriginalName": "tabletdriver\\.inf",
+    "ProviderName": "Graphics Tablet",
+    "ClassGuid": "88bae032-5a81-49f0-bc3d-a4ff138216d6"
+  },
+  {
+    "FriendlyName": "WinUSB (Gaomon)",
+    "OriginalName": "winusb\\.inf",
+    "ProviderName": "Gaomon",
+    "ClassGuid": "88bae032-5a81-49f0-bc3d-a4ff138216d6"
+  },
+  {
+    "FriendlyName": "WinUSB (Huion)",
+    "OriginalName": "winusb\\.inf",
+    "ProviderName": "Huion",
+    "ClassGuid": "88bae032-5a81-49f0-bc3d-a4ff138216d6"
+  },
+  {
+    "FriendlyName": "WinUSB (libwdi)",
+    "OriginalName": ".*",
+    "ProviderName": "libwdi",
+    "ClassGuid": "88bae032-5a81-49f0-bc3d-a4ff138216d6"
+  },
+  {
+    "FriendlyName": "USB-To-Serial (libwdi)",
+    "OriginalName": ".*",
+    "ProviderName": "libwdi",
+    "ClassGuid": "4d36e978-e325-11ce-bfc1-08002be10318"
+  }
+]

--- a/src/TabletDriverCleanup/Modules/DeviceToUninstall.cs
+++ b/src/TabletDriverCleanup/Modules/DeviceToUninstall.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 
 namespace TabletDriverCleanup.Modules;
 
@@ -14,10 +13,6 @@ public class DeviceToUninstall
     public string? ReplacementDriver { get; }
     public bool RemoveDevice => ReplacementDriver == null;
 
-    public Regex DeviceDescriptionRegex { get; }
-    public Regex? ManufacturerNameRegex { get; }
-    public Regex? HardwareIdRegex { get; }
-
     public DeviceToUninstall(
         string friendlyName,
         [StringSyntax(StringSyntaxAttribute.Regex)] string deviceDescription,
@@ -30,9 +25,5 @@ public class DeviceToUninstall
         ManufacturerName = manufacturerName;
         HardwareId = hardwareId;
         ClassGuid = classGuid;
-
-        DeviceDescriptionRegex = DeviceDescription.ToRegex();
-        ManufacturerNameRegex = ManufacturerName?.ToRegex();
-        HardwareIdRegex = HardwareId?.ToRegex();
     }
 }

--- a/src/TabletDriverCleanup/Modules/DriverToUninstall.cs
+++ b/src/TabletDriverCleanup/Modules/DriverToUninstall.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 
 namespace TabletDriverCleanup.Modules;
 
@@ -9,9 +8,6 @@ public class DriverToUninstall
     public string OriginalName { get; }
     public string? ProviderName { get; }
     public Guid? ClassGuid { get; }
-
-    public Regex OriginalNameRegex { get; }
-    public Regex? ProviderNameRegex { get; }
 
     public DriverToUninstall(
         string friendlyName,
@@ -23,8 +19,5 @@ public class DriverToUninstall
         OriginalName = originalName;
         ProviderName = providerName;
         ClassGuid = classGuid;
-
-        OriginalNameRegex = OriginalName.ToRegex();
-        ProviderNameRegex = ProviderName?.ToRegex();
     }
 }

--- a/src/TabletDriverCleanup/Program.cs
+++ b/src/TabletDriverCleanup/Program.cs
@@ -62,8 +62,14 @@ public static partial class Program
             {
                 Console.WriteLine(ex);
                 Console.WriteLine($"\nErrors were encountered while running '{module.Name}'. Aborting!");
-                Console.WriteLine("Press Enter to continue...");
-                Console.ReadKey();
+
+                if (state.Interactive)
+                {
+                    Console.WriteLine("Press Enter to continue...");
+                    Console.ReadKey();
+                }
+
+                Environment.Exit(1);
             }
         }
 

--- a/src/TabletDriverCleanup/Program.cs
+++ b/src/TabletDriverCleanup/Program.cs
@@ -123,6 +123,10 @@ public static partial class Program
                     state.Interactive = false;
                     break;
 
+                case "--no-cache":
+                    state.NoCache = true;
+                    break;
+
                 case string when arg.StartsWith("--no-"):
                     var moduleName = arg.AsSpan()[5..];
 
@@ -167,6 +171,7 @@ public static partial class Program
         Console.WriteLine("Options:");
 
         Console.WriteLine("  --no-prompt\t\t\tdo not prompt for user input");
+        Console.WriteLine("  --no-cache\t\t\tdo not use cached data in ./config");
 
         foreach (var module in state.Modules)
             Console.WriteLine($"  --no-{module.CliName}\t\t{module.DisablementDescription}");

--- a/src/TabletDriverCleanup/ProgramState.cs
+++ b/src/TabletDriverCleanup/ProgramState.cs
@@ -4,6 +4,7 @@ public class ProgramState
 {
     public string CurrentPath { get; } = AppDomain.CurrentDomain.BaseDirectory;
     public IReadOnlyList<ICleanupModule> Modules { get; }
+    public ConfigurationManager ConfigurationManager { get; }
 
     // CLI args
     public bool Interactive { get; set; } = true;
@@ -12,11 +13,11 @@ public class ProgramState
 
     // Runtime state
     public bool RebootNeeded { get; set; }
-
-    public Dictionary<string, object> Data { get; } = new Dictionary<string, object>();
+    public Dictionary<string, object> Data { get; } = new();
 
     public ProgramState(ICleanupModule[] modules)
     {
         Modules = modules;
+        ConfigurationManager = new ConfigurationManager(this);
     }
 }

--- a/src/TabletDriverCleanup/ProgramState.cs
+++ b/src/TabletDriverCleanup/ProgramState.cs
@@ -10,6 +10,7 @@ public class ProgramState
     public bool Interactive { get; set; } = true;
     public bool DryRun { get; set; }
     public bool Dump { get; set; }
+    public bool NoCache { get; set; }
 
     // Runtime state
     public bool RebootNeeded { get; set; }

--- a/src/TabletDriverCleanup/Services/ConfigurationManager.cs
+++ b/src/TabletDriverCleanup/Services/ConfigurationManager.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace TabletDriverCleanup;
+
+public class ConfigurationManager
+{
+    private const string CONFIG_BASE_URL = "https://raw.githubusercontent.com/X9VoiD/TabletDriverCleanup";
+    private const string REF = "json";
+    private readonly ProgramState _state;
+
+    public ConfigurationManager(ProgramState state)
+    {
+        _state = state;
+    }
+
+    public string this[string configurationName]
+        => TryGetConfiguration(configurationName, out string? configuration)
+            ? configuration
+            : throw new ArgumentException($"Configuration '{configurationName}' not found", nameof(configurationName));
+
+    public bool TryGetConfiguration(string configurationName, [NotNullWhen(true)] out string? configuration)
+    {
+        if (TryGetConfigurationOffline(configurationName, out configuration)
+            || TryGetConfigurationOnline(configurationName, out configuration)
+            || TryGetConfigurationInAssembly(configurationName, out configuration))
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    private bool TryGetConfigurationOffline(string configurationName, [NotNullWhen(true)] out string? configuration)
+    {
+        string targetPath = Path.Join(_state.CurrentPath, "config", configurationName);
+        if (!File.Exists(targetPath))
+        {
+            configuration = null;
+            return false;
+        }
+
+        try
+        {
+            configuration = File.ReadAllText(targetPath);
+            return true;
+        }
+        catch
+        {
+            configuration = null;
+            return false;
+        }
+    }
+
+    private bool TryGetConfigurationOnline(string configurationName, [NotNullWhen(true)] out string? configuration)
+    {
+        string targetDir = Path.Join(_state.CurrentPath, "config");
+        string targetPath = Path.Join(targetDir, configurationName);
+        if (!Directory.Exists(targetDir))
+            Directory.CreateDirectory(targetDir);
+
+        try
+        {
+            Downloader.Download($"{CONFIG_BASE_URL}/{REF}/config/{configurationName}", targetPath);
+            configuration = File.ReadAllText(targetPath);
+            return true;
+        }
+        catch
+        {
+            configuration = null;
+            return false;
+        }
+    }
+
+    private static bool TryGetConfigurationInAssembly(string configurationName, [NotNullWhen(true)] out string? configuration)
+    {
+        Assembly assembly = Assembly.GetExecutingAssembly();
+        string resourceName = $"TabletDriverCleanup.{configurationName}";
+
+        try
+        {
+            using Stream stream = assembly.GetManifestResourceStream(resourceName)!;
+            using StreamReader reader = new(stream);
+            configuration = reader.ReadToEnd();
+            return true;
+        }
+        catch
+        {
+            configuration = null;
+            return false;
+        }
+    }
+}

--- a/src/TabletDriverCleanup/Services/ConfigurationManager.cs
+++ b/src/TabletDriverCleanup/Services/ConfigurationManager.cs
@@ -6,7 +6,7 @@ namespace TabletDriverCleanup;
 public class ConfigurationManager
 {
     private const string CONFIG_BASE_URL = "https://raw.githubusercontent.com/X9VoiD/TabletDriverCleanup";
-    private const string REF = "json";
+    private const string REF = "v3.x";
     private readonly ProgramState _state;
 
     public ConfigurationManager(ProgramState state)
@@ -21,7 +21,7 @@ public class ConfigurationManager
 
     public bool TryGetConfiguration(string configurationName, [NotNullWhen(true)] out string? configuration)
     {
-        if (TryGetConfigurationOffline(configurationName, out configuration)
+        if ((!_state.NoCache && TryGetConfigurationOffline(configurationName, out configuration))
             || TryGetConfigurationOnline(configurationName, out configuration)
             || TryGetConfigurationInAssembly(configurationName, out configuration))
         {
@@ -56,7 +56,10 @@ public class ConfigurationManager
 
     private bool TryGetConfigurationOnline(string configurationName, [NotNullWhen(true)] out string? configuration)
     {
-        string targetDir = Path.Join(_state.CurrentPath, "config");
+        string targetDir = _state.NoCache
+            ? Path.Join(Path.GetTempPath(), Path.GetRandomFileName(), "config")
+            : Path.Join(_state.CurrentPath, "config");
+
         string targetPath = Path.Join(targetDir, configurationName);
         if (!Directory.Exists(targetDir))
             Directory.CreateDirectory(targetDir);

--- a/src/TabletDriverCleanup/Services/Downloader.cs
+++ b/src/TabletDriverCleanup/Services/Downloader.cs
@@ -1,0 +1,23 @@
+using System.Net;
+
+namespace TabletDriverCleanup;
+
+public static class Downloader
+{
+    public static void Download(string url, string path)
+    {
+        Task.Run(async () =>
+        {
+            using var client = new HttpClient();
+            using var response = await client.GetAsync(url);
+
+            if (!response.IsSuccessStatusCode)
+                throw new WebException($"Failed to download '{url}'");
+
+            using var content = response.Content;
+
+            var data = await content.ReadAsByteArrayAsync();
+            File.WriteAllBytes(path, data);
+        }).Wait();
+    }
+}

--- a/src/TabletDriverCleanup/Services/Downloader.cs
+++ b/src/TabletDriverCleanup/Services/Downloader.cs
@@ -17,6 +17,10 @@ public static class Downloader
             using var content = response.Content;
 
             var data = await content.ReadAsByteArrayAsync();
+
+            if (File.Exists(path))
+                File.Delete(path);
+
             File.WriteAllBytes(path, data);
         }).Wait();
     }

--- a/src/TabletDriverCleanup/Services/RegexCache.cs
+++ b/src/TabletDriverCleanup/Services/RegexCache.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace TabletDriverCleanup.Services;
+
+public class RegexCache
+{
+    private readonly Dictionary<string, Regex> _cache = new();
+
+    [return: NotNullIfNotNull("pattern")]
+    public Regex? GetRegex(string? pattern)
+    {
+        if (pattern is null)
+            return null;
+
+        ref var regex = ref CollectionsMarshal.GetValueRefOrAddDefault(_cache, pattern, out bool exists);
+        if (!exists)
+            regex = new Regex(pattern, RegexOptions.NonBacktracking);
+
+        return regex!;
+    }
+}

--- a/src/TabletDriverCleanup/TabletDriverCleanup.csproj
+++ b/src/TabletDriverCleanup/TabletDriverCleanup.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="../../config/**" />
     <PackageReference Include="Vanara.PInvoke.CfgMgr32" Version="3.4.13" />
     <PackageReference Include="Vanara.PInvoke.NewDev" Version="3.4.13" />
     <PackageReference Include="Vanara.PInvoke.SetupAPI" Version="3.4.13" />


### PR DESCRIPTION
Once `v3.x` branch is up, TabletDriverCleanup will start picking up identifiers from this repository. This makes it possible to add new identifiers without having to create another release.

## How it works

On launch, TabletDriverCleanup will check if specific files exist in `config` folder. When present, they will be used, otherwise TabletDriverCleanup will download `config` files from this repository.

As a bonus, this allows anybody to just add new identifiers offline without having to mess with code.

"Updating" the identifiers is as easy as just deleting the `config` folder to allow TabletDriverCleanup to refresh them. If there's no internet connection and no cache to use, the configurations/identifiers that are embedded into the binary itself will be used.